### PR TITLE
Add Content-Type header to json responses

### DIFF
--- a/handler/api_stub.go
+++ b/handler/api_stub.go
@@ -118,6 +118,7 @@ func (api *APIStub) CreateServiceAccount(w http.ResponseWriter, r *http.Request)
 
 func writeResponse(r Response, w http.ResponseWriter) {
 	b, _ := json.Marshal(r)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(r.Status)
 	w.Write(b)
 }


### PR DESCRIPTION
### What

Add Content-Type header to JSON responses.

The XLSX exporter was failing as it did not recognise a JSON content type in the response. It appears that the Zebedee endpoint sets the content type header correctly.
